### PR TITLE
Let's Encrypt + Payment URL

### DIFF
--- a/old/merchant.rst
+++ b/old/merchant.rst
@@ -34,7 +34,9 @@ Add your SSL certificate to your configuration
 ----------------------------------------------
 
 You should have a private key and a public certificate for
-your domain.
+your domain. A free certificate can be obtained from Let's 
+Encrypt. Specific instructions for your setup can be found 
+at 'https://certbot.eff.org/'. 
 
 Create a file that contains only the private key:
 
@@ -68,6 +70,14 @@ the root CA at the end.
    root cert
    -----END CERTIFICATE-----
 
+If you are using a Let's Encrypt certificate, you need to 
+replace your root cert with the intermediate and ISRG ROOT X1 
+certs in order to main compatibility among wallets. You can 
+find them here:
+
+https://letsencrypt.org/certs/letsencryptauthorityx3.pem.txt
+https://letsencrypt.org/certs/isrgrootx1.pem.txt
+
 
 Set the ssl_chain path with setconfig:
 
@@ -92,6 +102,17 @@ variable, url_rewrite. For example:
 .. code-block:: bash
 
    electron-cash setconfig url_rewrite "['file:///var/www/','https://electroncash.org/']"
+   
+Set the payment URL
+-------------------
+Although this field is optional, it will be necessary for some wallets. 
+Currently, the bitcoin.com wallet will ignore this field and use the 
+same URL that is provided by request_url. To maintain compatibility 
+accross wallets, set payment_url to the same URL provided in url_rewrite:
+
+.. code-block:: bash
+
+   electron-cash setconfig payment_url "https://electroncash.org/"
 
 Create a signed payment request
 -------------------------------
@@ -109,17 +130,22 @@ Create a signed payment request
       "index_url": "https://electroncash.org/r/index.html?id=7c2888541a",
       "memo": "this is a test", 
       "request_url": "https://electroncash.org/r/7c2888541a",
+      "payment_url": "https://electroncash.org/r/7c2888541a",
       "status": "Pending", 
       "time": 1450175741
    }
 
 This command returns a json object with two URLs:
 
- - request_url is the URL of the signed BIP70 request.
  - index_url is the URL of a webpage displaying the request.
+ - request_url is the URL of the signed BIP70 request (GET).
+ - payment_url (optional) is the URL where wallets will send the payment (POST).
 
 Note that request_url and index_url use the domain name we defined in
-url_rewrite.
+url_rewrite. Although payment_url is optional and can be set to any URL,
+we have set it to be the same as request_url here in order to maintain 
+compatibility with all wallets. 
+
 
 You can view the current list of requests using the 'listrequests'
 command.

--- a/old/merchant.rst
+++ b/old/merchant.rst
@@ -109,7 +109,7 @@ Set the payment URL
 Although this field is optional, it will be necessary for some wallets. 
 Currently, the bitcoin.com wallet will ignore this field and use the 
 same URL that is provided by request_url. To maintain compatibility 
-accross wallets, set payment_url to the same URL provided in url_rewrite:
+across wallets, set payment_url to the same URL provided in url_rewrite:
 
 .. code-block:: bash
 

--- a/old/merchant.rst
+++ b/old/merchant.rst
@@ -76,6 +76,7 @@ certs in order to main compatibility among wallets. You can
 find them here:
 
 https://letsencrypt.org/certs/letsencryptauthorityx3.pem.txt
+
 https://letsencrypt.org/certs/isrgrootx1.pem.txt
 
 


### PR DESCRIPTION
Explain how to use free Let's Encrypt cert and payment_url in a way that is compatible with most wallets.